### PR TITLE
Http source fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -517,7 +517,10 @@ file_watcher = ["bevy_internal/file_watcher"]
 embedded_watcher = ["bevy_internal/embedded_watcher"]
 
 # Enables using assets from HTTP sources
-http_source = ["bevy_internal/http_source"]
+http = ["bevy_internal/http"]
+
+# Enables using assets from HTTPS sources
+https = ["bevy_internal/https"]
 
 # Assets downloaded from HTTP sources are cached
 http_source_cache = ["bevy_internal/http_source_cache"]
@@ -620,7 +623,7 @@ nonmax = "0.5"
 smol = "2"
 smol-macros = "0.1"
 smol-hyper = "0.1"
-ureq = { version = "3", features = ["json"] }
+# ureq = { version = "3", features = ["json"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = { version = "0.2" }
@@ -1902,7 +1905,7 @@ wasm = false
 name = "http_source"
 path = "examples/asset/http_source.rs"
 doc-scrape-examples = true
-required-features = ["http_source"]
+required-features = ["https"]
 
 [package.metadata.example.http_source]
 name = "HTTP Asset Source"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,7 +623,7 @@ nonmax = "0.5"
 smol = "2"
 smol-macros = "0.1"
 smol-hyper = "0.1"
-# ureq = { version = "3", features = ["json"] }
+ureq = { version = "3", features = ["json"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -14,7 +14,8 @@ keywords = ["bevy"]
 file_watcher = ["notify-debouncer-full", "watch", "multi_threaded"]
 embedded_watcher = ["file_watcher"]
 multi_threaded = ["bevy_tasks/multi_threaded"]
-http_source = ["ureq"]
+http = ["ureq"]
+https = ["ureq", "ureq/rustls"]
 http_source_cache = []
 asset_processor = []
 watch = []
@@ -93,10 +94,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", default-featu
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.5.0", default-features = false, optional = true }
 # updating ureq: while ureq is semver stable, it depends on rustls which is not, meaning unlikely but possible breaking changes on minor releases. https://github.com/bevyengine/bevy/pull/16366#issuecomment-2572890794
-ureq = { version = "3", optional = true, default-features = false, features = [
-  "gzip",
-  "json",
-] }
+ureq = { version = "3", optional = true, default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -186,8 +186,8 @@ mod reflect;
 mod render_asset;
 mod server;
 
-#[cfg(feature = "http_source")]
-mod http_source;
+#[cfg(any(feature = "http", feature = "https"))]
+pub mod http_source;
 
 pub use assets::*;
 pub use bevy_asset_macros::Asset;
@@ -348,9 +348,6 @@ impl AssetPlugin {
 
 impl Plugin for AssetPlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(feature = "http_source")]
-        app.add_plugins(http_source::http_source_plugin);
-
         let embedded = EmbeddedAssetRegistry::default();
         {
             let mut sources = app

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -218,8 +218,11 @@ debug_glam_assert = ["bevy_math/debug_glam_assert"]
 
 default_font = ["bevy_text?/default_font"]
 
-# Enables using assets from HTTP sources
-http_source = ["bevy_asset?/http_source"]
+# Enables downloading assets from HTTP sources
+http = ["bevy_asset?/http"]
+
+# Enables downloading assets from HTTPS sources
+https = ["bevy_asset?/https"]
 
 # Assets downloaded from HTTP sources are cached
 http_source_cache = ["bevy_asset?/http_source_cache"]

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -21,6 +21,10 @@ plugin_group! {
         #[cfg(feature = "std")]
         #[custom(cfg(any(all(unix, not(target_os = "horizon")), windows)))]
         bevy_app:::TerminalCtrlCHandlerPlugin,
+        // NOTE: Load this before AssetPlugin to properly register http asset sources.
+        #[cfg(feature = "bevy_asset")]
+        #[custom(cfg(any(feature = "http", feature = "https")))]
+        bevy_asset::http_source:::HttpSourcePlugin,
         #[cfg(feature = "bevy_asset")]
         bevy_asset:::AssetPlugin,
         #[cfg(feature = "bevy_scene")]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -92,7 +92,8 @@ The default feature set enables most of the expected features of a game engine, 
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
 |gltf_convert_coordinates_default|Enable converting glTF coordinates to Bevy's coordinate system by default. This will be Bevy's default behavior starting in 0.18.|
 |hotpatching|Enable hotpatching of Bevy systems|
-|http_source|Enables using assets from HTTP sources|
+|http|Enables downloading assets from HTTP sources|
+|https|Enables downloading assets from HTTPS sources|
 |http_source_cache|Assets downloaded from HTTP sources are cached|
 |ico|ICO image format support|
 |jpeg|JPEG image format support|

--- a/examples/asset/http_source.rs
+++ b/examples/asset/http_source.rs
@@ -1,6 +1,6 @@
-//! Example usage of the `http` asset source to load assets from the web.
+//! Example usage of the `https` asset source to load assets from the web.
 //!
-//! Run with the feature `http_source`, and optionally `http_source_cache`
+//! Run with the feature `https`, and optionally `http_source_cache`
 //! for a simple caching mechanism that never invalidates.
 //!
 use bevy::prelude::*;


### PR DESCRIPTION
* Rename and split http_source feature to http and https
* Enable http sources when using processed asset mode
* Fix ureq/rustls feature gate (it was only working by accident because ureq with full features is part of the dev dependencies)
* Disable gzip and json ureq features
* Misc. rewording of a couple docs
* Setup HttpSourcePlugin as part of DefaultPlugins to allow for future configuration (there is currently none)

TODO: Add config option to specify allowed origins