### PR TITLE
Use `unblock` to make http requests run on separate threads

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["bevy"]
 file_watcher = ["notify-debouncer-full", "watch", "multi_threaded"]
 embedded_watcher = ["file_watcher"]
 multi_threaded = ["bevy_tasks/multi_threaded"]
-http = ["ureq"]
-https = ["ureq", "ureq/rustls"]
+http = ["blocking", "ureq"]
+https = ["blocking", "ureq", "ureq/rustls"]
 http_source_cache = []
 asset_processor = []
 watch = []
@@ -95,6 +95,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.17.0-dev", default-featu
 notify-debouncer-full = { version = "0.5.0", default-features = false, optional = true }
 # updating ureq: while ureq is semver stable, it depends on rustls which is not, meaning unlikely but possible breaking changes on minor releases. https://github.com/bevyengine/bevy/pull/16366#issuecomment-2572890794
 ureq = { version = "3", optional = true, default-features = false }
+blocking = { version = "1.6", optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Adds a new dependency on [blocking](https://crates.io/crates/blocking) when http/https features are enabled.

`unblock` is used when calling `AGENT.get` to execute the http request in a newly spawned thread. `blocking` uses a thread pool with a default size of 500.

This thread pool is entirely separate to bevy_tasks and its async executor which is desirable for reasons discussed in the PR and the linked discord thread.